### PR TITLE
[invoice] fix exception for selfdeaf

### DIFF
--- a/invoice/invoice.py
+++ b/invoice/invoice.py
@@ -326,11 +326,12 @@ class InVoice(commands.Cog):
                 await self._add_roles(m, a.channel, reason=reason, role_id=role.id)
         else:
             tc = m.guild.get_channel(await self.config.channel(a.channel).channel())
-            overs = tc.overwrites_for(m)
-            overs.read_messages = False if is_deaf else None
-            await tc.set_permissions(
-                target=m, overwrite=None if overs.is_empty() else overs, reason=reason
-            )
+            if tc:
+                overs = tc.overwrites_for(m)
+                overs.read_messages = False if is_deaf else None
+                await tc.set_permissions(
+                    target=m, overwrite=None if overs.is_empty() else overs, reason=reason
+                )
 
     async def _add_roles(self, m, c, *, reason, role_id=None, guild_role_id=None):
         guild = m.guild


### PR DESCRIPTION
```py
Ignoring exception in on_voice_state_update
Traceback (most recent call last):
  File "/home/fixator/Red-V3/lib/python3.8/site-packages/discord/client.py", line 312, in _run_event
    await coro(*args, **kwargs)
  File "/home/fixator/.local/share/Red-DiscordBot/cogs/CogManager/cogs/invoice/invoice.py", line 260, in on_voice_state_update
    await self.self_deaf_update(member, before, after)
  File "/home/fixator/.local/share/Red-DiscordBot/cogs/CogManager/cogs/invoice/invoice.py", line 317, in self_deaf_update
    await self._deaf_update(m, b, a, reason="Self {un}deafened", is_deaf=a.self_deaf)
  File "/home/fixator/.local/share/Red-DiscordBot/cogs/CogManager/cogs/invoice/invoice.py", line 329, in _deaf_update
    overs = tc.overwrites_for(m)
AttributeError: 'NoneType' object has no attribute 'overwrites_for'
```