### PR TITLE
Remove youtube_dl import from AntiGifV

### DIFF
--- a/antigifv/antigifv.py
+++ b/antigifv/antigifv.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import discord
-import youtube_dl
 from redbot.core import commands
 from redbot.core.bot import Red
 


### PR DESCRIPTION
Loading AntiGifV raises ModuleNotFoundError if the `youtube_dl` library had not been installed previously (it had not been listed in the cog's requirements). Seeing as its not being used, I just simply removed the import.