### PR TITLE
[rtfs] use utf-8 to open info.json

### DIFF
--- a/rtfs/__init__.py
+++ b/rtfs/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from .rtfs import RTFS
 
-with open(Path(__file__).parent / "info.json") as fp:
+with open(Path(__file__).parent / "info.json", encoding="UTF-8") as fp:
     __red_end_user_data_statement__ = json.load(fp)["end_user_data_statement"]
 
 


### PR DESCRIPTION
Currently, it fails to load on windows due to `cp1251` default encoding

*Not tested*