### PR TITLE
Remove teardown since it's unnecessary

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -78,9 +78,3 @@ async def sync(
 
 async def setup(bot: Red):
     bot.add_command(sync)
-
-
-async def teardown(bot: Red):
-    cmd = bot.remove_command("sync")
-    if cmd and cmd is not sync:
-        bot.add_command(cmd)


### PR DESCRIPTION
The library will automatically remove extension scoped commands for you.

I don't think Red messes with the extension mechanism enough (or at all?) to make this invariant false.

One more suggestion I could do is to use `Annotated` in place of the `TYPE_CHECKING` block however this requires either 3.9+ or typing_extensions as a runtime dependency, which I was not sure you had.

PS: Sorry for the lack of prefix, I didn't notice the commit formatting until after I had made the commit.