### PR TITLE
[SecureInv] `Commands.BotMissingPermissions` and `Commands.MissingPermissions` now require an instance of `discord.Permissions` as an argument, not a list of str.

### DIFF
--- a/secureinv/secureinv.py
+++ b/secureinv/secureinv.py
@@ -70,9 +70,9 @@ class SecureInv(commands.Cog):
             channel = ctx.guild.get_channel(settings["channel"])
         channel = channel or ctx.channel
         if not channel.permissions_for(ctx.me).create_instant_invite:
-            raise commands.BotMissingPermissions(["create_instant_invite"])
+            raise commands.BotMissingPermissions(discord.Permissions(1))
         if not channel.permissions_for(ctx.author).create_instant_invite:
-            raise commands.MissingPermissions(["create_instant_invite"])
+            raise commands.MissingPermissions(discord.Permissions(1))
         if days is None:
             days = settings["days"]
         if uses is None:

--- a/secureinv/secureinv.py
+++ b/secureinv/secureinv.py
@@ -70,9 +70,9 @@ class SecureInv(commands.Cog):
             channel = ctx.guild.get_channel(settings["channel"])
         channel = channel or ctx.channel
         if not channel.permissions_for(ctx.me).create_instant_invite:
-            raise commands.BotMissingPermissions(discord.Permissions(1))
+            raise commands.BotMissingPermissions(discord.Permissions(create_instant_invite=True))
         if not channel.permissions_for(ctx.author).create_instant_invite:
-            raise commands.MissingPermissions(discord.Permissions(1))
+            raise commands.MissingPermissions(discord.Permissions(create_instant_invite=True))
         if days is None:
             days = settings["days"]
         if uses is None:


### PR DESCRIPTION
Hello,
The `commands.BotMissingPermissions` and `commands.MissingPermissions` exceptions no longer require the same type of argument as before.
Have a nice day,
AAA3A