### PR TITLE
[LogsFrom] `Commands.BotMissingPermissions` and `Commands.MissingPermissions` now require an instance of discord.Permissions as an argument, not a list of str.

### DIFF
--- a/logsfrom/logsfrom.py
+++ b/logsfrom/logsfrom.py
@@ -94,9 +94,9 @@ class LogsFrom(commands.Cog):
             channel = ctx.channel
             ctxc = ctx
         if not channel.permissions_for(ctx.me).read_message_history:
-            raise commands.BotMissingPermissions(["read_message_history"])
+            raise commands.BotMissingPermissions(discord.Permissions(read_message_history=True))
         if not await check_permissions(ctxc, {"read_message_history": True}):
-            raise commands.MissingPermissions(["read_message_history"])
+            raise commands.MissingPermissions(discord.Permissions(read_message_history=True))
         after, before = getattr(after, "id", after), getattr(before, "id", before)
         cancel_task = asyncio.ensure_future(
             ctx.bot.wait_for("message", check=MessagePredicate.cancelled(ctx))

--- a/logsfrom/logsfrom.py
+++ b/logsfrom/logsfrom.py
@@ -96,7 +96,7 @@ class LogsFrom(commands.Cog):
         if not channel.permissions_for(ctx.me).read_message_history:
             raise commands.BotMissingPermissions(discord.Permissions(read_message_history=True))
         if not await check_permissions(ctxc, {"read_message_history": True}):
-            raise commands.MissingPermissions(discord.Permissions(read_message_history=True))
+            raise commands.MissingPermissions(["read_message_history"])
         after, before = getattr(after, "id", after), getattr(before, "id", before)
         cancel_task = asyncio.ensure_future(
             ctx.bot.wait_for("message", check=MessagePredicate.cancelled(ctx))


### PR DESCRIPTION
Hello,
The `commands.BotMissingPermissions` and `commands.MissingPermissions` exceptions no longer require the same type of argument as before.
This PR is the same as #65. This time I checked for all your cogs.
Have a nice day,
AAA3A