### PR TITLE
[RTFS] Use `redbot.core.dev_commands.cleanup_code` because `Dev.cleanup_code` because it no longer exists.

### DIFF
--- a/rtfs/rtfs.py
+++ b/rtfs/rtfs.py
@@ -11,6 +11,7 @@ import discord
 import redbot
 from redbot.core import commands
 from redbot.core.bot import Red
+from redbot.core.dev_commands import cleanup_code
 from redbot.core.utils.chat_formatting import box, pagify
 
 try:
@@ -250,7 +251,7 @@ class RTFS(commands.Cog):
             raise commands.UserFeedbackCheckFailure(
                 f"I couldn't find any cog or command named `{thing}`."
             )
-        thing = dev.cleanup_code(thing)
+        thing = cleanup_code(thing)
         env = dev.get_environment(ctx)
         env["getattr_static"] = inspect.getattr_static
         try:


### PR DESCRIPTION
Hello,

With https://github.com/Cog-Creators/Red-DiscordBot/pull/5843, `redbot.core.dev_commands.Dev.cleanup_code` is moved and is now `redbot.core.dev_commands.cleanup_code`.
The RTFS cog no longer works under the latest development version of Red 3.5.
```
Traceback (most recent call last):
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{USERPROFILE}\AppData\Local\Red-DiscordBot\Red-DiscordBot\data\dpy2\cogs\CogManager\cogs\rtfs\rtfs.py", line 253, in rtfs
    thing = dev.cleanup_code(thing)
            ^^^^^^^^^^^^^^^^
AttributeError: 'Dev' object has no attribute 'cleanup_code'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\bot.py", line 1350, in invoke
    await ctx.command.invoke(ctx)
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\core.py", line 1023, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\core.py", line 238, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: 'Dev' object has no attribute 'cleanup_code'
```

Thanks in advance,
Have a nice day,
AAA3A